### PR TITLE
Update typing_extensions due to incompatible version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,7 @@
 name = "llama_stack_client"
 version = "0.1.0"
 description = "The official Python library for the llama-stack-client API"
-dynamic = ["readme"]
-license = "Apache-2.0"
+license = { text = "Apache License 2.0" }
 authors = [
 { name = "Llama Stack Client", email = "dev-feedback@llama-stack-client.com" },
 ]
@@ -94,9 +93,6 @@ typecheck = { chain = [
 "typecheck:verify-types" = "pyright --verifytypes llama_stack_client --ignoreexternal"
 "typecheck:mypy" = "mypy ."
 
-[build-system]
-requires = ["hatchling", "hatch-fancy-pypi-readme"]
-build-backend = "hatchling.build"
 
 [tool.hatch.build]
 include = [

--- a/requirements.lock
+++ b/requirements.lock
@@ -69,7 +69,7 @@ termcolor==2.5.0
     # via llama-stack-client
 tqdm==4.67.1
     # via llama-stack-client
-typing-extensions==4.8.0
+typing-extensions==4.12.2
     # via anyio
     # via llama-stack-client
     # via pydantic


### PR DESCRIPTION
# What does this PR do?
Couldn't build llama-stack due to `typeIs` couldn't be imported

Ran `pip install -U typing_extensions` to upgrade outdated `typing_extensions` from `llama-stack-client`.
<img width="949" alt="Screenshot 2025-01-26 at 12 57 14 PM" src="https://github.com/user-attachments/assets/bcdd48c3-18f0-4aa2-a3d9-d651902af480" />

- [X] Addresses issue (#99)



## Test Plan
- Build both `llama-stack-client` and `llama-stack` distro locally. The distro could start and started serving
<img width="998" alt="Screenshot 2025-01-26 at 12 50 09 PM" src="https://github.com/user-attachments/assets/1d3249bb-6db1-441d-a69b-7de315b42e01" />

<img width="1090" alt="Screenshot 2025-01-26 at 2 08 33 PM" src="https://github.com/user-attachments/assets/db89b40e-e35c-424f-8a55-208e570ecab4" />

- [X] Wrote necessary unit or integration tests.
