### PR TITLE
feat: Updating Llama Stack ENV var names

### DIFF
--- a/src/llama_stack_client/_client.py
+++ b/src/llama_stack_client/_client.py
@@ -126,14 +126,14 @@ class LlamaStackClient(SyncAPIClient):
     ) -> None:
         """Construct a new synchronous llama-stack-client client instance.
 
-        This automatically infers the `api_key` argument from the `LLAMA_STACK_CLIENT_API_KEY` environment variable if it is not provided.
+        This automatically infers the `api_key` argument from the `LLAMA_STACK_API_KEY` environment variable if it is not provided.
         """
         if api_key is None:
-            api_key = os.environ.get("LLAMA_STACK_CLIENT_API_KEY")
+            api_key = os.environ.get("LLAMA_STACK_API_KEY")
         self.api_key = api_key
 
         if base_url is None:
-            base_url = os.environ.get("LLAMA_STACK_CLIENT_BASE_URL")
+            base_url = os.environ.get("LLAMA_STACK_BASE_URL")
         if base_url is None:
             base_url = f"http://any-hosted-llama-stack.com"
 
@@ -342,14 +342,14 @@ class AsyncLlamaStackClient(AsyncAPIClient):
     ) -> None:
         """Construct a new async llama-stack-client client instance.
 
-        This automatically infers the `api_key` argument from the `LLAMA_STACK_CLIENT_API_KEY` environment variable if it is not provided.
+        This automatically infers the `api_key` argument from the `LLAMA_STACK_API_KEY` environment variable if it is not provided.
         """
         if api_key is None:
-            api_key = os.environ.get("LLAMA_STACK_CLIENT_API_KEY")
+            api_key = os.environ.get("LLAMA_STACK_API_KEY")
         self.api_key = api_key
 
         if base_url is None:
-            base_url = os.environ.get("LLAMA_STACK_CLIENT_BASE_URL")
+            base_url = os.environ.get("LLAMA_STACK_BASE_URL")
         if base_url is None:
             base_url = f"http://any-hosted-llama-stack.com"
 

--- a/src/llama_stack_client/_utils/_logs.py
+++ b/src/llama_stack_client/_utils/_logs.py
@@ -14,7 +14,7 @@ def _basic_config() -> None:
 
 
 def setup_logging() -> None:
-    env = os.environ.get("LLAMA_STACK_CLIENT_LOG")
+    env = os.environ.get("LLAMA_STACK_LOG")
     if env == "debug":
         _basic_config()
         logger.setLevel(logging.DEBUG)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -526,7 +526,7 @@ class TestLlamaStackClient:
         assert client.base_url == "https://example.com/from_setter/"
 
     def test_base_url_env(self) -> None:
-        with update_env(LLAMA_STACK_CLIENT_BASE_URL="http://localhost:5000/from/env"):
+        with update_env(LLAMA_STACK_BASE_URL="http://localhost:5000/from/env"):
             client = LlamaStackClient(_strict_response_validation=True)
             assert client.base_url == "http://localhost:5000/from/env/"
 
@@ -1316,7 +1316,7 @@ class TestAsyncLlamaStackClient:
         assert client.base_url == "https://example.com/from_setter/"
 
     def test_base_url_env(self) -> None:
-        with update_env(LLAMA_STACK_CLIENT_BASE_URL="http://localhost:5000/from/env"):
+        with update_env(LLAMA_STACK_BASE_URL="http://localhost:5000/from/env"):
             client = AsyncLlamaStackClient(_strict_response_validation=True)
             assert client.base_url == "http://localhost:5000/from/env/"
 


### PR DESCRIPTION
# What does this PR do?

We are updating ENV var names to follow shorter naming pattern, the env vars will be prefixed by LLAMA_STACK instead of LLAMA_STACK_CLIENT which was previously auto-generated by Stainless by reading the project name field in the spec, but Stainless added a new feature where we can override this prefix.

## Test Plan

```
export LLAMA_STACK_BASE_URL=<base-url>
export LLAMA_STACK_API_KEY=<api-key>
```

```
from llama_stack_client import LlamaStackClient
client = LlamaStackClient()

# will create a client pointing to <base-url>, with <api-key>.
```