### PR TITLE
fix: more types in client_tool type conversion

### DIFF
--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -129,6 +129,14 @@ class ClientTool:
 
 T = TypeVar("T", bound=Callable)
 
+# python typehint to litellm/openai parameter spec
+TYPEHINT_TO_LITELLM_TYPE = {
+    "int": "integer",
+    "float": "number",
+    "bool": "boolean",
+    "str": "string",
+}
+
 
 def client_tool(func: T) -> ClientTool:
     """
@@ -197,8 +205,7 @@ def client_tool(func: T) -> ClientTool:
                 params[name] = Parameter(
                     name=name,
                     description=param_doc or f"Parameter {name}",
-                    # Hack: litellm/openai expects "string" for str type
-                    parameter_type=type_hint.__name__ if type_hint.__name__ != "str" else "string",
+                    parameter_type=TYPEHINT_TO_LITELLM_TYPE.get(type_hint.__name__, type_hint.__name__),
                     default=(param.default if param.default != inspect.Parameter.empty else None),
                     required=is_required,
                 )


### PR DESCRIPTION

Summary:

Test Plan:
LLAMA_STACK_CONFIG=fireworks pytest -s -v tests/integration/agents/test_agents.py::test_create_turn_response --safety-shield meta-llama/Llama-Guard-3-8B --text-model meta-llama/Llama-3.1-8B-Instruct --record-responses

LLAMA_STACK_CONFIG=dev pytest -s -v tests/integration/agents/test_agents.py::test_create_turn_response --safety-shield meta-llama/Llama-Guard-3-8B --text-model openai/gpt-4o-mini --record-responses
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/meta-llama/llama-stack-client-python/pull/191).
* #192
* __->__ #191