### PR TITLE
fix: Don't retry for non-recoverable server http errors

### DIFF
--- a/src/llama_stack_client/_base_client.py
+++ b/src/llama_stack_client/_base_client.py
@@ -734,7 +734,11 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
             return True
 
         # Retry internal errors.
-        if response.status_code >= 500:
+        if response.status_code in (
+            502, # Bad Gateway
+            503, # Service Unavailable
+            504, # Gateway Timeout
+        ):
             log.debug("Retrying due to status code %i", response.status_code)
             return True
 


### PR DESCRIPTION
# What does this PR do?

This is specifically addressing the issue where server returning Not
Implemented (code 501) would receive two more attempts for the same
request, even though there's no reason to expect it to serve the request
any better on further attempts.

This patch reduces the number of >=500 codes that would be restarted to
those where there seems to be a chance of recover on further attempts.
These codes are now explicitly listed instead of broad >=500 filter.

For all possible server codes, please consult e.g. here:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status#server_error_responses

## Test Plan

Client no longer retries requests when server fails.

Injected a fake `raise NotImplementedError` in one of providers. Then triggered the API. Confirmed that the server no longer logs three times the following, but just once:

```
"POST /v1/datasets HTTP/1.1" 501 Not Implemented
```