### PR TITLE
Fix LLAMA_STACK_LOG in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,10 @@ Note that requests that time out are [retried twice by default](#retries).
 
 We use the standard library [`logging`](https://docs.python.org/3/library/logging.html) module.
 
-You can enable logging by setting the environment variable `LLAMA_STACK_CLIENT_LOG` to `debug`.
+You can enable logging by setting the environment variable `LLAMA_STACK_LOG` to `debug`.
 
 ```shell
-$ export LLAMA_STACK_CLIENT_LOG=debug
+$ export LLAMA_STACK_LOG=debug
 ```
 
 ### How to tell whether `None` means `null` or missing


### PR DESCRIPTION
The readme calls to use `LLAMA_STACK_CLIENT_LOG` env var to enable debug logs, but that's not the value we are using in the code [1].

Update it to use the right env var name: `LLAMA_STACK_LOG`.

One could argue that `LLAMA_STACK_CLIENT_LOG` is a better name (considering llama-stack uses `LLAMA_STACK_LOGGING`), but if we want to change it we'll need to allow using both, which is easy enough to do if that's what we want:

```
    env = os.environ.get("LLAMA_STACK_CLIENT_LOG") or os.environ.get("LLAMA_STACK_LOG")
```

[1]: https://github.com/meta-llama/llama-stack-client-python/blob/52c0b5d23e9ae67ceb09d755143d436f38c20547/src/llama_stack_client/_utils/_logs.py#L19