### PR TITLE
fix: update CLI to use new OpenAI-format Model type

### DIFF
--- a/src/llama_stack_client/lib/cli/inference/inference.py
+++ b/src/llama_stack_client/lib/cli/inference/inference.py
@@ -40,7 +40,9 @@ def chat_completion(ctx, message: str, stream: bool, session: bool, model_id: Op
     console = Console()
 
     if not model_id:
-        available_models = [model.identifier for model in client.models.list() if model.model_type == "llm"]
+        available_models = [
+            model.id for model in client.models.list() if (model.custom_metadata or {}).get("model_type") == "llm"
+        ]
         model_id = available_models[0]
 
     messages = []

--- a/src/llama_stack_client/lib/cli/models/models.py
+++ b/src/llama_stack_client/lib/cli/models/models.py
@@ -51,12 +51,13 @@ def list_models(ctx):
         table.add_column("provider_id", style="green", max_width=20)
 
         for item in response:
+            cm = item.custom_metadata or {}
             table.add_row(
-                item.model_type,
-                item.identifier,
-                item.provider_resource_id,
-                str(item.metadata or ""),
-                item.provider_id,
+                str(cm.get("model_type", "")),
+                item.id,
+                str(cm.get("provider_resource_id", "")),
+                str(cm.get("metadata", "")),
+                str(cm.get("provider_id", "")),
             )
 
         # Create a title for the table


### PR DESCRIPTION
The Stainless-regenerated Model type no longer has model_type, identifier, provider_resource_id, metadata, or provider_id as direct attributes. These are now in custom_metadata dict.