### PR TITLE
feat: add ReasoningItem output type for Responses API

### DIFF
--- a/src/llama_stack_client/types/response_object.py
+++ b/src/llama_stack_client/types/response_object.py
@@ -40,6 +40,9 @@ __all__ = [
     "OutputOpenAIResponseOutputMessageMcpListTools",
     "OutputOpenAIResponseOutputMessageMcpListToolsTool",
     "OutputOpenAIResponseMcpApprovalRequest",
+    "OutputOpenAIResponseReasoningItem",
+    "OutputOpenAIResponseReasoningItemContent",
+    "OutputOpenAIResponseReasoningItemSummary",
     "Error",
     "IncompleteDetails",
     "Prompt",
@@ -403,12 +406,49 @@ class OutputOpenAIResponseMcpApprovalRequest(BaseModel):
     type: Optional[Literal["mcp_approval_request"]] = None
 
 
+class OutputOpenAIResponseReasoningItemContent(BaseModel):
+    """Reasoning text content from the model's chain-of-thought."""
+
+    text: str
+
+    type: Optional[Literal["reasoning_text"]] = None
+
+
+class OutputOpenAIResponseReasoningItemSummary(BaseModel):
+    """Summary of the model's reasoning output."""
+
+    text: str
+
+    type: Optional[Literal["summary_text"]] = None
+
+
+class OutputOpenAIResponseReasoningItem(BaseModel):
+    """Reasoning output item for OpenAI responses.
+
+    Contains the model's chain-of-thought reasoning, either as raw content
+    (open-source models) or as a summary (closed-source models).
+    """
+
+    id: str
+
+    summary: List[OutputOpenAIResponseReasoningItemSummary]
+
+    content: Optional[List[OutputOpenAIResponseReasoningItemContent]] = None
+
+    encrypted_content: Optional[str] = None
+
+    status: Optional[Literal["in_progress", "completed", "incomplete"]] = None
+
+    type: Optional[Literal["reasoning"]] = None
+
+
 Output: TypeAlias = Annotated[
     Union[
         OutputOpenAIResponseMessageOutput,
         OutputOpenAIResponseOutputMessageWebSearchToolCall,
         OutputOpenAIResponseOutputMessageFileSearchToolCall,
         OutputOpenAIResponseOutputMessageFunctionToolCall,
+        OutputOpenAIResponseReasoningItem,
         OutputOpenAIResponseOutputMessageMcpCall,
         OutputOpenAIResponseOutputMessageMcpListTools,
         OutputOpenAIResponseMcpApprovalRequest,

--- a/src/llama_stack_client/types/response_object_stream.py
+++ b/src/llama_stack_client/types/response_object_stream.py
@@ -42,6 +42,9 @@ __all__ = [
     "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseOutputMessageMcpListTools",
     "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseOutputMessageMcpListToolsTool",
     "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMcpApprovalRequest",
+    "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseReasoningItem",
+    "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseReasoningItemContent",
+    "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseReasoningItemSummary",
     "OpenAIResponseObjectStreamResponseOutputItemDone",
     "OpenAIResponseObjectStreamResponseOutputItemDoneItem",
     "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessage",
@@ -67,6 +70,9 @@ __all__ = [
     "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseOutputMessageMcpListTools",
     "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseOutputMessageMcpListToolsTool",
     "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMcpApprovalRequest",
+    "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseReasoningItem",
+    "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseReasoningItemContent",
+    "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseReasoningItemSummary",
     "OpenAIResponseObjectStreamResponseOutputTextDelta",
     "OpenAIResponseObjectStreamResponseOutputTextDeltaLogprob",
     "OpenAIResponseObjectStreamResponseOutputTextDeltaLogprobTopLogprob",
@@ -491,12 +497,45 @@ class OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMcpAppr
     type: Optional[Literal["mcp_approval_request"]] = None
 
 
+class OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseReasoningItemContent(BaseModel):
+    """Reasoning text content from the model's chain-of-thought."""
+
+    text: str
+
+    type: Optional[Literal["reasoning_text"]] = None
+
+
+class OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseReasoningItemSummary(BaseModel):
+    """Summary of the model's reasoning output."""
+
+    text: str
+
+    type: Optional[Literal["summary_text"]] = None
+
+
+class OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseReasoningItem(BaseModel):
+    """Reasoning output item for OpenAI responses."""
+
+    id: str
+
+    summary: List[OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseReasoningItemSummary]
+
+    content: Optional[List[OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseReasoningItemContent]] = None
+
+    encrypted_content: Optional[str] = None
+
+    status: Optional[str] = None
+
+    type: Optional[Literal["reasoning"]] = None
+
+
 OpenAIResponseObjectStreamResponseOutputItemAddedItem: TypeAlias = Annotated[
     Union[
         OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessage,
         OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseOutputMessageWebSearchToolCall,
         OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseOutputMessageFileSearchToolCall,
         OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseOutputMessageFunctionToolCall,
+        OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseReasoningItem,
         OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseOutputMessageMcpCall,
         OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseOutputMessageMcpListTools,
         OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMcpApprovalRequest,
@@ -860,12 +899,45 @@ class OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMcpAppro
     type: Optional[Literal["mcp_approval_request"]] = None
 
 
+class OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseReasoningItemContent(BaseModel):
+    """Reasoning text content from the model's chain-of-thought."""
+
+    text: str
+
+    type: Optional[Literal["reasoning_text"]] = None
+
+
+class OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseReasoningItemSummary(BaseModel):
+    """Summary of the model's reasoning output."""
+
+    text: str
+
+    type: Optional[Literal["summary_text"]] = None
+
+
+class OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseReasoningItem(BaseModel):
+    """Reasoning output item for OpenAI responses."""
+
+    id: str
+
+    summary: List[OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseReasoningItemSummary]
+
+    content: Optional[List[OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseReasoningItemContent]] = None
+
+    encrypted_content: Optional[str] = None
+
+    status: Optional[str] = None
+
+    type: Optional[Literal["reasoning"]] = None
+
+
 OpenAIResponseObjectStreamResponseOutputItemDoneItem: TypeAlias = Annotated[
     Union[
         OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessage,
         OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseOutputMessageWebSearchToolCall,
         OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseOutputMessageFileSearchToolCall,
         OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseOutputMessageFunctionToolCall,
+        OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseReasoningItem,
         OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseOutputMessageMcpCall,
         OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseOutputMessageMcpListTools,
         OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMcpApprovalRequest,

--- a/src/llama_stack_client/types/response_object_stream.py
+++ b/src/llama_stack_client/types/response_object_stream.py
@@ -520,7 +520,9 @@ class OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseReasoni
 
     summary: List[OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseReasoningItemSummary]
 
-    content: Optional[List[OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseReasoningItemContent]] = None
+    content: Optional[List[OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseReasoningItemContent]] = (
+        None
+    )
 
     encrypted_content: Optional[str] = None
 
@@ -922,7 +924,9 @@ class OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseReasonin
 
     summary: List[OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseReasoningItemSummary]
 
-    content: Optional[List[OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseReasoningItemContent]] = None
+    content: Optional[List[OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseReasoningItemContent]] = (
+        None
+    )
 
     encrypted_content: Optional[str] = None
 


### PR DESCRIPTION
## Summary

The LlamaStack client's `Output` union was missing a `ReasoningItem` variant, causing `type: "reasoning"` output items from the Responses API to be deserialized as the generic `OutputOpenAIResponseMessageOutput` instead of a dedicated type. This adds `OutputOpenAIResponseReasoningItem` to both non-streaming and streaming response types.

## Problem

When a server returns reasoning output (from reasoning-capable models), the response includes items with `type: "reasoning"`. The client's discriminated `Output` union had no variant for this type, so Pydantic fell back to `OutputOpenAIResponseMessageOutput`.

### Why it appears to "work" but is actually broken

The client's `BaseModel` is configured with `extra: 'allow'`, so Pydantic silently accepts unknown fields like `summary` and `encrypted_content` as untyped extras on the wrong class:

```python
resp.output[0]
# OutputOpenAIResponseMessageOutput(
#   content=None,          <-- None! reasoning data is NOT here
#   role=None,             <-- None! not a message
#   id='rs_resp_874653',
#   status=None,
#   type='reasoning',      <-- correct type string, wrong Python class
#   summary=[{'type': 'summary_text', 'text': '...'}],   <-- untyped extra field (raw dict)
#   encrypted_content='...'                                <-- untyped extra field
# )
```

This means:
- **`content` is `None`** — `resp.output[0].content[0].text` raises `TypeError: 'NoneType' object is not subscriptable`
- **`summary` exists but as raw dicts** — no `.text` attribute, no type validation, no IDE autocompletion
- **`role` is `None`** — the class expects it as a required `Literal["system", "developer", "user", "assistant"]` but Pydantic's `extra: 'allow'` lets it slide
- **No type safety** — code checking `isinstance(item, ReasoningItem)` would fail

## Setup to reproduce

```bash
# Pull a reasoning-capable model
ollama pull gpt-oss:20b

# Install clients
pip install llama-stack-client openai
```

## Before (broken) — non-streaming

Using OpenAI client as reference (correct behavior):
```python
from openai import OpenAI

client = OpenAI(base_url="http://localhost:11434/v1", api_key="unused")
MODEL = "gpt-oss:20b"

resp = client.responses.create(
    model=MODEL,
    input="What is 2 + 2? Think step by step.",
    reasoning={"effort": "low"},
    stream=False,
)

for item in resp.output:
    print(f"type={item.type!r}, python_type={type(item).__name__}")
# type='reasoning', python_type=ResponseReasoningItem   <-- correct
# type='message',   python_type=ResponseOutputMessage    <-- correct
```

Same call with LlamaStack client (broken):
```python
from llama_stack_client import LlamaStackClient

ls_client = LlamaStackClient(base_url="http://localhost:11434/")
MODEL = "gpt-oss:20b"

resp = ls_client.responses.create(
    model=MODEL,
    input="What is 2 + 2? Think step by step.",
    reasoning={"effort": "low"},
    stream=False,
)

for item in resp.output:
    print(f"type={item.type!r}, python_type={type(item).__name__}")
# type='reasoning', python_type=OutputOpenAIResponseMessageOutput   <-- WRONG
# type='message',   python_type=OutputOpenAIResponseMessageOutput

resp.output[0].content[0].text
# TypeError: 'NoneType' object is not subscriptable
```

## After (fixed) — non-streaming

```python
from llama_stack_client import LlamaStackClient

ls_client = LlamaStackClient(base_url="http://localhost:11434/")
MODEL = "gpt-oss:20b"

resp = ls_client.responses.create(
    model=MODEL,
    input="What is 2 + 2? Think step by step.",
    reasoning={"effort": "low"},
    stream=False,
)

for item in resp.output:
    print(f"type={item.type!r}, python_type={type(item).__name__}")
# type='reasoning', python_type=OutputOpenAIResponseReasoningItem   <-- correct!
# type='message',   python_type=OutputOpenAIResponseMessageOutput

# Reasoning fields properly typed and accessible:
print(resp.output[0].summary[0].type)   # 'summary_text'  <-- typed object, not raw dict

import json
print(json.dumps(resp.output[0].model_dump(), indent=2))
# {
#   "id": "rs_resp_645183",
#   "summary": [
#     {
#       "text": "The user asks \"What is 2 + 2?\" ...",
#       "type": "summary_text"
#     }
#   ],
#   "content": null,
#   "encrypted_content": "The user asks \"What is 2 + 2?\" ...",
#   "status": null,
#   "type": "reasoning"
# }
```

## After (fixed) — streaming

```python
events = list(ls_client.responses.create(
    model=MODEL,
    input="What is 2 + 2? Think step by step.",
    reasoning={"effort": "low"},
    stream=True,
))

for e in events:
    etype = getattr(e, 'type', None)
    item = getattr(e, 'item', None)
    if item and hasattr(item, 'type'):
        print(f"  {etype:<45} item.type={item.type}")
    else:
        print(f"  {etype}")

# Output:
#   response.created
#   response.in_progress
#   response.output_item.added
#   response.reasoning_summary_text.delta
#   ...
#   response.reasoning_summary_text.done
#   response.output_item.done
#   response.output_item.added
#   response.content_part.added
#   response.output_text.delta
#   ...
#   response.output_text.done
#   response.content_part.done
#   response.output_item.done
#   response.completed

# Final output correctly typed:
final = events[-1].response.output
print(type(final[0]).__name__)  # OutputOpenAIResponseReasoningItem
print(type(final[1]).__name__)  # OutputOpenAIResponseMessageOutput
```

## Changes

| File | Change |
|------|--------|
| `src/llama_stack_client/types/response_object.py` | Added `OutputOpenAIResponseReasoningItem`, `OutputOpenAIResponseReasoningItemContent`, `OutputOpenAIResponseReasoningItemSummary` + added to `Output` discriminated union |
| `src/llama_stack_client/types/response_object_stream.py` | Added matching reasoning types for `OutputItemAdded` and `OutputItemDone` item unions |

## Test plan

- [x] `type: "reasoning"` correctly deserializes into `OutputOpenAIResponseReasoningItem` in both streaming and non-streaming modes
- [x] Tested with OpenAI client against Ollama (`gpt-oss:20b`) as ground truth
- [x] Non-reasoning responses unaffected