### PR TITLE
Fix logging env var name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,10 +398,10 @@ Note that requests that time out are [retried twice by default](#retries).
 
 We use the standard library [`logging`](https://docs.python.org/3/library/logging.html) module.
 
-You can enable logging by setting the environment variable `LLAMA_STACK_LOG` to `debug`.
+You can enable logging by setting the environment variable `LLAMA_STACK_CLIENT_LOG` to `debug`.
 
 ```shell
-$ export LLAMA_STACK_LOG=debug
+$ export LLAMA_STACK_CLIENT_LOG=debug
 ```
 
 ### How to tell whether `None` means `null` or missing


### PR DESCRIPTION
## Summary
- update the README logging docs to use LLAMA_STACK_CLIENT_LOG
- align the example export command with the code in src/llama_stack_client/_utils/_logs.py

Closes #214