### PR TITLE
Improve agent event logger output for empty tool results

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,10 +398,10 @@ Note that requests that time out are [retried twice by default](#retries).
 
 We use the standard library [`logging`](https://docs.python.org/3/library/logging.html) module.
 
-You can enable logging by setting the environment variable `LLAMA_STACK_LOG` to `debug`.
+You can enable logging by setting the environment variable `LLAMA_STACK_CLIENT_LOG` to `debug`.
 
 ```shell
-$ export LLAMA_STACK_LOG=debug
+$ export LLAMA_STACK_CLIENT_LOG=debug
 ```
 
 ### How to tell whether `None` means `null` or missing

--- a/src/llama_stack_client/lib/agents/event_logger.py
+++ b/src/llama_stack_client/lib/agents/event_logger.py
@@ -115,6 +115,9 @@ class AgentEventLogger:
                     for resp in result.tool_responses:
                         tool_name = resp.get("tool_name", "unknown")
                         content = resp.get("content", "")
+                        if content is None or content == "":
+                            yield f"  → {tool_name}\n"
+                            continue
                         # Truncate long responses for readability
                         if isinstance(content, str) and len(content) > 100:
                             content = content[:100] + "..."

--- a/tests/lib/agents/test_event_logger.py
+++ b/tests/lib/agents/test_event_logger.py
@@ -1,0 +1,35 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from llama_stack_client.lib.agents.event_logger import AgentEventLogger
+from llama_stack_client.lib.agents.turn_events import StepCompleted, ToolExecutionStepResult
+
+
+def test_agent_event_logger_omits_empty_tool_response_fields() -> None:
+    event = StepCompleted(
+        step_id="step_empty_fields",
+        step_type="tool_execution",
+        turn_id="turn_empty_fields",
+        result=ToolExecutionStepResult(
+            step_id="step_empty_fields",
+            tool_calls=[],
+            tool_responses=[
+                {"tool_name": "no_content_tool", "content": ""},
+                {"tool_name": "null_content_tool", "content": None},
+                {"tool_name": "valid_content_tool", "content": "abc"},
+            ],
+        ),
+    )
+
+    logger = AgentEventLogger()
+    messages = list(logger.log(iter([event])))
+
+    assert messages == [
+        "  → no_content_tool\n",
+        "  → null_content_tool\n",
+        "  → valid_content_tool: abc\n",
+    ]
+

--- a/tests/lib/agents/test_event_logger.py
+++ b/tests/lib/agents/test_event_logger.py
@@ -1,0 +1,34 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from llama_stack_client.lib.agents.event_logger import AgentEventLogger
+from llama_stack_client.lib.agents.turn_events import AgentStreamChunk, StepCompleted, ToolExecutionStepResult
+
+
+def test_agent_event_logger_omits_empty_tool_response_fields() -> None:
+    event = StepCompleted(
+        step_id="step_empty_fields",
+        step_type="tool_execution",
+        turn_id="turn_empty_fields",
+        result=ToolExecutionStepResult(
+            step_id="step_empty_fields",
+            tool_calls=[],
+            tool_responses=[
+                {"tool_name": "no_content_tool", "content": ""},
+                {"tool_name": "null_content_tool", "content": None},
+                {"tool_name": "valid_content_tool", "content": "abc"},
+            ],
+        ),
+    )
+
+    logger = AgentEventLogger()
+    messages = list(logger.log(iter([AgentStreamChunk(event=event)])))
+
+    assert messages == [
+        "  → no_content_tool\n",
+        "  → null_content_tool\n",
+        "  → valid_content_tool: abc\n",
+    ]


### PR DESCRIPTION
## Summary\n- Avoid printing empty content placeholders for client-side tool results.\n- Render tool result lines without a trailing ": " when content is empty or null.\n- Add regression coverage for output formatting when tool payloads are empty or null.\n\n## Testing\n- Not run in this environment (network and env constraints).