### PR TITLE
ci: fix workflows after llama->ogx CLI rename

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,6 +13,7 @@ on:
       - 'release-[0-9]+.[0-9]+.x'
     types: [opened, synchronize, reopened]
     paths:
+      - 'src/ogx_client/**'
       - 'src/llama_stack_client/**'
       - 'uv.lock'
       - 'pyproject.toml'
@@ -107,7 +108,7 @@ jobs:
         run: |
           echo "Building Llama Stack"
           LLAMA_STACK_DIR=. \
-            uv run --no-sync llama stack list-deps ci-tests | xargs -L1 uv pip install
+            uv run --no-sync ogx stack list-deps ci-tests | xargs -L1 uv pip install
 
       - name: Configure git for commits
         if: ${{ matrix.config.allowed_clients == null || contains(matrix.config.allowed_clients, matrix.client) }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,19 +17,19 @@ repos:
     rev: v0.9.4
     hooks:
     -   id: ruff
-        files: ^src/llama_stack_client/lib/.*
+        files: ^src/(ogx_client|llama_stack_client)/lib/.*
         args: [
             --fix,
             --exit-non-zero-on-fix
         ]
     -   id: ruff-format
-        files: ^src/llama_stack_client/lib/.*
+        files: ^src/(ogx_client|llama_stack_client)/lib/.*
 
 -   repo: https://github.com/adamchainz/blacken-docs
     rev: 1.19.0
     hooks:
     -   id: blacken-docs
-        files: ^src/llama_stack_client/lib/.*
+        files: ^src/(ogx_client|llama_stack_client)/lib/.*
         additional_dependencies:
         - black==24.3.0
 
@@ -60,7 +60,7 @@ repos:
     rev: v1.5.5
     hooks:
     -   id: insert-license
-        files: \.py$|\.sh$
+        files: ^src/(ogx_client|llama_stack_client)/lib/.*\.(py|sh)$
         args:
           - --license-filepath
           - scripts/license_header.txt


### PR DESCRIPTION
## Summary
- Update integration-tests.yml to invoke \`ogx stack list-deps\` (was \`llama\`); add \`src/ogx_client/**\` to path filter
- Scope pre-commit ruff/blacken-docs/insert-license hooks to \`src/(ogx_client|llama_stack_client)/lib/.*\` so insert-license stops adding Meta headers to Stainless-generated files under \`src/ogx_client/types/\` and \`src/ogx_client/_utils/\`

Unblocks the failing CI on #337.

## Test plan
- [ ] Integration Tests workflow finds the \`ogx\` binary (was failing with \`Failed to spawn: 'llama'\`)
- [ ] Pre-commit no longer rewrites generated SDK files