### PR TITLE
feat(cli): wire up ogx-client CLI entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ Repository = "https://github.com/ogx-ai/ogx-client-python"
 [project.optional-dependencies]
 aiohttp = ["aiohttp", "httpx_aiohttp>=0.1.9"]
 
+[project.scripts]
+ogx-client = "ogx_client.lib.cli.ogx_client:main"
+
 [tool.uv]
 managed = true
 required-version = ">=0.9"

--- a/src/ogx_client/lib/agents/agent.py
+++ b/src/ogx_client/lib/agents/agent.py
@@ -306,7 +306,7 @@ class AsyncAgent:
         """Construct an async Agent backed by the responses + conversations APIs.
 
         Args:
-            client: An async OpenAI-compatible client (e.g., openai.AsyncOpenAI() or AsyncLlamaStackClient).
+            client: An async OpenAI-compatible client (e.g., openai.AsyncOpenAI() or AsyncOgxClient).
                     The client must support the responses and conversations APIs.
         """
         self.client = client

--- a/src/ogx_client/lib/cli/configure.py
+++ b/src/ogx_client/lib/cli/configure.py
@@ -13,7 +13,7 @@ import yaml
 import click
 from prompt_toolkit import prompt
 from prompt_toolkit.validation import Validator
-from llama_stack_client.lib.cli.constants import LLAMA_STACK_CLIENT_CONFIG_DIR, get_config_file_path
+from ogx_client.lib.cli.constants import OGX_CLIENT_CONFIG_DIR, get_config_file_path
 
 
 def get_config():
@@ -26,18 +26,18 @@ def get_config():
 
 @click.command()
 @click.help_option("-h", "--help")
-@click.option("--endpoint", type=str, help="Llama Stack distribution endpoint", default="")
-@click.option("--api-key", type=str, help="Llama Stack distribution API key", default="")
+@click.option("--endpoint", type=str, help="OGX server endpoint", default="")
+@click.option("--api-key", type=str, help="OGX server API key", default="")
 def configure(endpoint: str | None, api_key: str | None):
-    """Configure Llama Stack Client CLI."""
-    os.makedirs(LLAMA_STACK_CLIENT_CONFIG_DIR, exist_ok=True)
+    """Configure OGX Client CLI."""
+    os.makedirs(OGX_CLIENT_CONFIG_DIR, exist_ok=True)
     config_path = get_config_file_path()
 
     if endpoint != "":
         final_endpoint = endpoint
     else:
         final_endpoint = prompt(
-            "> Enter the endpoint of the Llama Stack distribution server: ",
+            "> Enter the endpoint of the OGX server: ",
             validator=Validator.from_callable(
                 lambda x: len(x) > 0 and (parsed := urlparse(x)).scheme and parsed.netloc,
                 error_message="Endpoint cannot be empty and must be a valid URL, please enter a valid endpoint",
@@ -66,4 +66,4 @@ def configure(endpoint: str | None, api_key: str | None):
             )
         )
 
-    print(f"Done! You can now use the Llama Stack Client CLI with endpoint {final_endpoint}")  # noqa: T201
+    print(f"Done! You can now use the OGX Client CLI with endpoint {final_endpoint}")  # noqa: T201

--- a/src/ogx_client/lib/cli/constants.py
+++ b/src/ogx_client/lib/cli/constants.py
@@ -7,8 +7,8 @@
 import os
 from pathlib import Path
 
-LLAMA_STACK_CLIENT_CONFIG_DIR = Path(os.path.expanduser("~/.llama/client"))
+OGX_CLIENT_CONFIG_DIR = Path(os.path.expanduser("~/.ogx/client"))
 
 
 def get_config_file_path():
-    return LLAMA_STACK_CLIENT_CONFIG_DIR / "config.yaml"
+    return OGX_CLIENT_CONFIG_DIR / "config.yaml"

--- a/src/ogx_client/lib/cli/eval/run_scoring.py
+++ b/src/ogx_client/lib/cli/eval/run_scoring.py
@@ -22,7 +22,7 @@ from tqdm.rich import tqdm
 @click.option(
     "--dataset-id",
     required=False,
-    help="Pre-registered dataset_id to score (from llama-stack-client datasets list)",
+    help="Pre-registered dataset_id to score (from ogx-client datasets list)",
 )
 @click.option(
     "--dataset-path",
@@ -82,7 +82,7 @@ def run_scoring(
         dataset = client.datasets.retrieve(dataset_id=dataset_id)
         if not dataset:
             click.BadParameter(
-                f"Dataset {dataset_id} not found. Please register using llama-stack-client datasets register"
+                f"Dataset {dataset_id} not found. Please register using ogx-client datasets register"
             )
 
         # TODO: this will eventually be replaced with jobs polling from server vis score_bath

--- a/src/ogx_client/lib/cli/eval/run_scoring.py
+++ b/src/ogx_client/lib/cli/eval/run_scoring.py
@@ -81,9 +81,7 @@ def run_scoring(
     if dataset_id is not None:
         dataset = client.datasets.retrieve(dataset_id=dataset_id)
         if not dataset:
-            click.BadParameter(
-                f"Dataset {dataset_id} not found. Please register using ogx-client datasets register"
-            )
+            click.BadParameter(f"Dataset {dataset_id} not found. Please register using ogx-client datasets register")
 
         # TODO: this will eventually be replaced with jobs polling from server vis score_bath
         # For now, get all datasets rows via datasets API

--- a/src/ogx_client/lib/cli/inspect/version.py
+++ b/src/ogx_client/lib/cli/inspect/version.py
@@ -15,7 +15,7 @@ from ..common.utils import handle_client_errors
 @click.pass_context
 @handle_client_errors("inspect version")
 def inspect_version(ctx):
-    """Show Llama Stack version on distribution endpoint"""
+    """Show OGX server version on distribution endpoint"""
     client = ctx.obj["client"]
     console = Console()
     version_response = client.inspect.version()

--- a/src/ogx_client/lib/cli/models/models.py
+++ b/src/ogx_client/lib/cli/models/models.py
@@ -20,7 +20,7 @@ def models():
     """Manage GenAI models."""
 
 
-@click.command(name="list", help="Show available llama models at distribution endpoint")
+@click.command(name="list", help="Show available models at distribution endpoint")
 @click.help_option("-h", "--help")
 @click.pass_context
 @handle_client_errors("list models")

--- a/src/ogx_client/lib/cli/ogx_client.py
+++ b/src/ogx_client/lib/cli/ogx_client.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
 from __future__ import annotations
 
 import os

--- a/src/ogx_client/lib/cli/ogx_client.py
+++ b/src/ogx_client/lib/cli/ogx_client.py
@@ -1,12 +1,7 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import os
+import json
 from importlib.metadata import version
 
 import yaml
@@ -30,16 +25,15 @@ from .scoring_functions import scoring_functions
 
 @click.group()
 @click.help_option("-h", "--help")
-@click.version_option(version=version("ogx-client"), prog_name="llama-stack-client")
-@click.option("--endpoint", type=str, help="Llama Stack distribution endpoint", default="")
-@click.option("--api-key", type=str, help="Llama Stack distribution API key", default="")
+@click.version_option(version=version("ogx_client"), prog_name="ogx-client")
+@click.option("--endpoint", type=str, help="OGX server endpoint", default="")
+@click.option("--api-key", type=str, help="OGX server API key", default="")
 @click.option("--config", type=str, help="Path to config file", default=None)
 @click.pass_context
-def llama_stack_client(ctx, endpoint: str, api_key: str, config: str | None):
-    """Welcome to the llama-stack-client CLI - a command-line interface for interacting with Llama Stack"""
+def ogx_client(ctx, endpoint: str, api_key: str, config: str | None):
+    """Welcome to the ogx-client CLI - a command-line interface for interacting with an OGX server"""
     ctx.ensure_object(dict)
 
-    # If no config provided, check default location
     if config and endpoint:
         raise ValueError("Cannot use both config and endpoint")
 
@@ -61,40 +55,45 @@ def llama_stack_client(ctx, endpoint: str, api_key: str, config: str | None):
     if endpoint == "":
         endpoint = "http://localhost:8321"
 
-    default_headers = {}
+    default_headers: dict[str, str] = {}
     if api_key != "":
-        default_headers = {
-            "Authorization": f"Bearer {api_key}",
-        }
+        default_headers["Authorization"] = f"Bearer {api_key}"
 
-    client = OgxClient(
-        base_url=endpoint,
-        provider_data={
+    provider_data = {
+        k: v
+        for k, v in {
             "fireworks_api_key": os.environ.get("FIREWORKS_API_KEY", ""),
             "together_api_key": os.environ.get("TOGETHER_API_KEY", ""),
             "openai_api_key": os.environ.get("OPENAI_API_KEY", ""),
-        },
+        }.items()
+        if v
+    }
+    if provider_data:
+        default_headers["X-OGX-Provider-Data"] = json.dumps(provider_data)
+
+    client = OgxClient(
+        base_url=endpoint,
+        api_key=api_key or None,
         default_headers=default_headers,
     )
     ctx.obj = {"client": client}
 
 
-# Register all subcommands
-llama_stack_client.add_command(models, "models")
-llama_stack_client.add_command(vector_stores, "vector_stores")
-llama_stack_client.add_command(shields, "shields")
-llama_stack_client.add_command(eval_tasks, "eval_tasks")
-llama_stack_client.add_command(providers, "providers")
-llama_stack_client.add_command(datasets, "datasets")
-llama_stack_client.add_command(configure, "configure")
-llama_stack_client.add_command(scoring_functions, "scoring_functions")
-llama_stack_client.add_command(eval, "eval")
-llama_stack_client.add_command(inference, "inference")
-llama_stack_client.add_command(inspect, "inspect")
+ogx_client.add_command(models, "models")
+ogx_client.add_command(vector_stores, "vector_stores")
+ogx_client.add_command(shields, "shields")
+ogx_client.add_command(eval_tasks, "eval_tasks")
+ogx_client.add_command(providers, "providers")
+ogx_client.add_command(datasets, "datasets")
+ogx_client.add_command(configure, "configure")
+ogx_client.add_command(scoring_functions, "scoring_functions")
+ogx_client.add_command(eval, "eval")
+ogx_client.add_command(inference, "inference")
+ogx_client.add_command(inspect, "inspect")
 
 
 def main():
-    llama_stack_client()
+    ogx_client()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Register `ogx-client` as a console script in `pyproject.toml`
- Rename `lib/cli/llama_stack_client.py` → `ogx_client.py`; rename group, prog_name, and help text
- Construct `OgxClient` with `api_key`/`default_headers` (the Stainless-generated client no longer accepts `provider_data`); pack provider keys into the `X-OGX-Provider-Data` header
- Fix stale `from llama_stack_client...` import in `configure.py` that crashed every CLI invocation
- Move client config dir from `~/.llama/client` to `~/.ogx/client`; rename `LLAMA_STACK_CLIENT_CONFIG_DIR` → `OGX_CLIENT_CONFIG_DIR`
- Replace remaining `Llama Stack` / `llama-stack-client` / `llama models` strings in CLI command help and messages with `OGX` / `ogx-client`
- Update stray `AsyncLlamaStackClient` reference in `lib/agents/agent.py` docstring

Stainless covers the SDK types and resources but doesn't generate the CLI, so this stitches the renamed CLI back together so `ogx-client` actually works.

## Test plan
- [x] \`pip install -e .\` succeeds
- [x] \`ogx-client --help\` lists subcommands and shows \`OGX\` branding
- [x] \`ogx-client --version\` returns the package version
- [x] \`ogx-client configure --help\`, \`models --help\`, \`inspect --help\` load without import errors
- [ ] End-to-end smoke against a running OGX server