### PR TITLE
chore: drop Meta licensing (hook + headers)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,16 +56,6 @@ repos:
 #       args: ['--quiet']
 
 
--   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.5
-    hooks:
-    -   id: insert-license
-        files: ^src/(ogx_client|llama_stack_client)/lib/.*\.(py|sh)$
-        args:
-          - --license-filepath
-          - scripts/license_header.txt
-
-
 ci:
     autofix_commit_msg: 🎨 [pre-commit.ci] Auto format from pre-commit.com hooks
     autoupdate_commit_msg: ⬆ [pre-commit.ci] pre-commit autoupdate

--- a/examples/interactive_agent_cli.py
+++ b/examples/interactive_agent_cli.py
@@ -1,9 +1,4 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
 """Interactive CLI for exploring agent turn/step events with server-side tools.
 
 Usage:

--- a/scripts/license_header.txt
+++ b/scripts/license_header.txt
@@ -1,5 +1,0 @@
-Copyright (c) Meta Platforms, Inc. and affiliates.
-All rights reserved.
-
-This source code is licensed under the terms described in the LICENSE file in
-the root directory of this source tree.

--- a/scripts/utils/ruffen-docs.py
+++ b/scripts/utils/ruffen-docs.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # fork of https://github.com/asottile/blacken-docs adapted for ruff
 from __future__ import annotations
 

--- a/scripts/utils/upload-artifact.sh
+++ b/scripts/utils/upload-artifact.sh
@@ -1,10 +1,4 @@
 #!/bin/bash
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 set -exuo pipefail
 
 FILENAME=$(basename dist/*.whl)

--- a/src/ogx_client/__init__.py
+++ b/src/ogx_client/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import typing as _t

--- a/src/ogx_client/_base_client.py
+++ b/src/ogx_client/_base_client.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import sys

--- a/src/ogx_client/_compat.py
+++ b/src/ogx_client/_compat.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Union, Generic, TypeVar, Callable, cast, overload

--- a/src/ogx_client/_constants.py
+++ b/src/ogx_client/_constants.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import httpx

--- a/src/ogx_client/_exceptions.py
+++ b/src/ogx_client/_exceptions.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/_files.py
+++ b/src/ogx_client/_files.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import io

--- a/src/ogx_client/_models.py
+++ b/src/ogx_client/_models.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import os

--- a/src/ogx_client/_qs.py
+++ b/src/ogx_client/_qs.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 from typing import Any, List, Tuple, Union, Mapping, TypeVar

--- a/src/ogx_client/_resource.py
+++ b/src/ogx_client/_resource.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/_response.py
+++ b/src/ogx_client/_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import os

--- a/src/ogx_client/_streaming.py
+++ b/src/ogx_client/_streaming.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # Note: initially copied from https://github.com/florimondmanca/httpx-sse/blob/master/src/httpx_sse/_decoders.py
 from __future__ import annotations
 

--- a/src/ogx_client/_types.py
+++ b/src/ogx_client/_types.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 from os import PathLike

--- a/src/ogx_client/_utils/__init__.py
+++ b/src/ogx_client/_utils/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from ._path import path_template as path_template
 from ._sync import asyncify as asyncify
 from ._proxy import LazyProxy as LazyProxy

--- a/src/ogx_client/_utils/_compat.py
+++ b/src/ogx_client/_utils/_compat.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import sys

--- a/src/ogx_client/_utils/_datetime_parse.py
+++ b/src/ogx_client/_utils/_datetime_parse.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 """
 This file contains code from https://github.com/pydantic/pydantic/blob/main/pydantic/v1/datetime_parse.py
 without the Pydantic v1 specific errors.

--- a/src/ogx_client/_utils/_json.py
+++ b/src/ogx_client/_utils/_json.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import json
 from typing import Any
 from datetime import datetime

--- a/src/ogx_client/_utils/_path.py
+++ b/src/ogx_client/_utils/_path.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import re

--- a/src/ogx_client/_utils/_proxy.py
+++ b/src/ogx_client/_utils/_proxy.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/src/ogx_client/_utils/_reflection.py
+++ b/src/ogx_client/_utils/_reflection.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import inspect

--- a/src/ogx_client/_utils/_streams.py
+++ b/src/ogx_client/_utils/_streams.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from typing import Any
 from typing_extensions import Iterator, AsyncIterator
 

--- a/src/ogx_client/_utils/_sync.py
+++ b/src/ogx_client/_utils/_sync.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import asyncio

--- a/src/ogx_client/_utils/_transform.py
+++ b/src/ogx_client/_utils/_transform.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import io

--- a/src/ogx_client/_utils/_typing.py
+++ b/src/ogx_client/_utils/_typing.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import sys

--- a/src/ogx_client/_utils/_utils.py
+++ b/src/ogx_client/_utils/_utils.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import os

--- a/src/ogx_client/_version.py
+++ b/src/ogx_client/_version.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 __title__ = "ogx_client"

--- a/src/ogx_client/_wrappers.py
+++ b/src/ogx_client/_wrappers.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Generic, TypeVar

--- a/src/ogx_client/lib/__init__.py
+++ b/src/ogx_client/lib/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 __all__ = ["get_oauth_token_for_mcp_server"]
 
 

--- a/src/ogx_client/lib/agents/__init__.py
+++ b/src/ogx_client/lib/agents/__init__.py
@@ -1,5 +1,0 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.

--- a/src/ogx_client/lib/agents/agent.py
+++ b/src/ogx_client/lib/agents/agent.py
@@ -1,8 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
 from __future__ import annotations
 
 import json

--- a/src/ogx_client/lib/agents/client_tool.py
+++ b/src/ogx_client/lib/agents/client_tool.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import json
 import inspect
 from abc import abstractmethod

--- a/src/ogx_client/lib/agents/event_logger.py
+++ b/src/ogx_client/lib/agents/event_logger.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 """Event logger for agent interactions.
 
 This module provides a simple logger that converts agent stream events

--- a/src/ogx_client/lib/agents/event_synthesizer.py
+++ b/src/ogx_client/lib/agents/event_synthesizer.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 """Translate Responses API stream events into structured turn events.
 
 TurnEventSynthesizer keeps just enough state to expose turns and steps for

--- a/src/ogx_client/lib/agents/react/__init__.py
+++ b/src/ogx_client/lib/agents/react/__init__.py
@@ -1,5 +1,0 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.

--- a/src/ogx_client/lib/agents/react/agent.py
+++ b/src/ogx_client/lib/agents/react/agent.py
@@ -1,8 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
 from __future__ import annotations
 
 import logging

--- a/src/ogx_client/lib/agents/react/prompts.py
+++ b/src/ogx_client/lib/agents/react/prompts.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 DEFAULT_REACT_AGENT_SYSTEM_PROMPT_TEMPLATE = """
 You are an expert assistant who can solve any task using tool calls. You will be given a task to solve as best you can.
 To do so, you have been given access to the following tools: <<tool_names>>

--- a/src/ogx_client/lib/agents/react/tool_parser.py
+++ b/src/ogx_client/lib/agents/react/tool_parser.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import json
 import uuid
 from typing import List, Union, Optional

--- a/src/ogx_client/lib/agents/tool_parser.py
+++ b/src/ogx_client/lib/agents/tool_parser.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from abc import abstractmethod
 from typing import List
 

--- a/src/ogx_client/lib/agents/turn_events.py
+++ b/src/ogx_client/lib/agents/turn_events.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 """High-level turn and step events for agent interactions.
 
 This module defines the semantic event model that wraps the lower-level

--- a/src/ogx_client/lib/agents/types.py
+++ b/src/ogx_client/lib/agents/types.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 """Lightweight agent-facing types that avoid llama-stack SDK dependencies."""
 
 from __future__ import annotations

--- a/src/ogx_client/lib/cli/__init__.py
+++ b/src/ogx_client/lib/cli/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # Ignore tqdm experimental warning
 import warnings
 

--- a/src/ogx_client/lib/cli/common/__init__.py
+++ b/src/ogx_client/lib/cli/common/__init__.py
@@ -1,5 +1,0 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.

--- a/src/ogx_client/lib/cli/common/utils.py
+++ b/src/ogx_client/lib/cli/common/utils.py
@@ -1,8 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
 from functools import wraps
 
 from rich.panel import Panel

--- a/src/ogx_client/lib/cli/configure.py
+++ b/src/ogx_client/lib/cli/configure.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import os

--- a/src/ogx_client/lib/cli/constants.py
+++ b/src/ogx_client/lib/cli/constants.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import os
 from pathlib import Path
 

--- a/src/ogx_client/lib/cli/datasets/__init__.py
+++ b/src/ogx_client/lib/cli/datasets/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from .datasets import datasets
 
 __all__ = ["datasets"]

--- a/src/ogx_client/lib/cli/datasets/datasets.py
+++ b/src/ogx_client/lib/cli/datasets/datasets.py
@@ -1,8 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
 import click
 
 from .list import list_datasets

--- a/src/ogx_client/lib/cli/datasets/list.py
+++ b/src/ogx_client/lib/cli/datasets/list.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import click
 from rich.table import Table
 from rich.console import Console

--- a/src/ogx_client/lib/cli/datasets/register.py
+++ b/src/ogx_client/lib/cli/datasets/register.py
@@ -1,8 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
 import os
 import json
 import base64

--- a/src/ogx_client/lib/cli/datasets/unregister.py
+++ b/src/ogx_client/lib/cli/datasets/unregister.py
@@ -1,8 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
 import click
 
 from ..common.utils import handle_client_errors

--- a/src/ogx_client/lib/cli/eval/__init__.py
+++ b/src/ogx_client/lib/cli/eval/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from .eval import eval
 
 __all__ = ["eval"]

--- a/src/ogx_client/lib/cli/eval/eval.py
+++ b/src/ogx_client/lib/cli/eval/eval.py
@@ -1,10 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
-
 import click
 
 from .run_scoring import run_scoring

--- a/src/ogx_client/lib/cli/eval/run_benchmark.py
+++ b/src/ogx_client/lib/cli/eval/run_benchmark.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import os

--- a/src/ogx_client/lib/cli/eval/run_scoring.py
+++ b/src/ogx_client/lib/cli/eval/run_scoring.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import os

--- a/src/ogx_client/lib/cli/eval/utils.py
+++ b/src/ogx_client/lib/cli/eval/utils.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from typing import Any, Dict, List, Union
 
 

--- a/src/ogx_client/lib/cli/eval_tasks/__init__.py
+++ b/src/ogx_client/lib/cli/eval_tasks/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from .eval_tasks import eval_tasks
 
 __all__ = ["eval_tasks"]

--- a/src/ogx_client/lib/cli/eval_tasks/eval_tasks.py
+++ b/src/ogx_client/lib/cli/eval_tasks/eval_tasks.py
@@ -1,10 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
-
 from __future__ import annotations
 
 import json

--- a/src/ogx_client/lib/cli/eval_tasks/list.py
+++ b/src/ogx_client/lib/cli/eval_tasks/list.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import click
 from rich.table import Table
 from rich.console import Console

--- a/src/ogx_client/lib/cli/inference/__init__.py
+++ b/src/ogx_client/lib/cli/inference/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from .inference import inference
 
 __all__ = ["inference"]

--- a/src/ogx_client/lib/cli/inference/inference.py
+++ b/src/ogx_client/lib/cli/inference/inference.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import traceback
 from typing import Dict, List, Optional
 

--- a/src/ogx_client/lib/cli/inspect/__init__.py
+++ b/src/ogx_client/lib/cli/inspect/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from .inspect import inspect
 
 __all__ = ["inspect"]

--- a/src/ogx_client/lib/cli/inspect/inspect.py
+++ b/src/ogx_client/lib/cli/inspect/inspect.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import click
 
 from .version import inspect_version

--- a/src/ogx_client/lib/cli/inspect/version.py
+++ b/src/ogx_client/lib/cli/inspect/version.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import click
 from rich.console import Console
 

--- a/src/ogx_client/lib/cli/llama_stack_client.py
+++ b/src/ogx_client/lib/cli/llama_stack_client.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import os

--- a/src/ogx_client/lib/cli/models/__init__.py
+++ b/src/ogx_client/lib/cli/models/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from .models import models
 
 __all__ = ["models"]

--- a/src/ogx_client/lib/cli/models/models.py
+++ b/src/ogx_client/lib/cli/models/models.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import json
 from typing import Optional
 

--- a/src/ogx_client/lib/cli/providers/__init__.py
+++ b/src/ogx_client/lib/cli/providers/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from .providers import providers
 
 __all__ = ["providers"]

--- a/src/ogx_client/lib/cli/providers/inspect.py
+++ b/src/ogx_client/lib/cli/providers/inspect.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import yaml
 import click
 from rich.console import Console

--- a/src/ogx_client/lib/cli/providers/list.py
+++ b/src/ogx_client/lib/cli/providers/list.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import click
 from rich.table import Table
 from rich.console import Console

--- a/src/ogx_client/lib/cli/providers/providers.py
+++ b/src/ogx_client/lib/cli/providers/providers.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import click
 
 from .list import list_providers

--- a/src/ogx_client/lib/cli/scoring_functions/__init__.py
+++ b/src/ogx_client/lib/cli/scoring_functions/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from .scoring_functions import scoring_functions
 
 __all__ = ["scoring_functions"]

--- a/src/ogx_client/lib/cli/scoring_functions/list.py
+++ b/src/ogx_client/lib/cli/scoring_functions/list.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import click
 from rich.table import Table
 from rich.console import Console

--- a/src/ogx_client/lib/cli/scoring_functions/scoring_functions.py
+++ b/src/ogx_client/lib/cli/scoring_functions/scoring_functions.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import json
 from typing import Optional
 

--- a/src/ogx_client/lib/cli/shields/__init__.py
+++ b/src/ogx_client/lib/cli/shields/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from .shields import shields
 
 __all__ = ["shields"]

--- a/src/ogx_client/lib/cli/shields/shields.py
+++ b/src/ogx_client/lib/cli/shields/shields.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from typing import Optional
 
 import yaml

--- a/src/ogx_client/lib/cli/vector_stores/__init__.py
+++ b/src/ogx_client/lib/cli/vector_stores/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from .vector_stores import vector_stores
 
 __all__ = ["vector_stores"]

--- a/src/ogx_client/lib/cli/vector_stores/vector_stores.py
+++ b/src/ogx_client/lib/cli/vector_stores/vector_stores.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from typing import Optional
 
 import yaml

--- a/src/ogx_client/lib/inference/__init__.py
+++ b/src/ogx_client/lib/inference/__init__.py
@@ -1,5 +1,0 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.

--- a/src/ogx_client/lib/inference/event_logger.py
+++ b/src/ogx_client/lib/inference/event_logger.py
@@ -1,8 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
 from typing import Generator
 
 from termcolor import cprint

--- a/src/ogx_client/lib/inference/utils.py
+++ b/src/ogx_client/lib/inference/utils.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import base64
 import pathlib
 

--- a/src/ogx_client/lib/inline/inline.py
+++ b/src/ogx_client/lib/inline/inline.py
@@ -1,5 +1,0 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.

--- a/src/ogx_client/lib/stream_printer.py
+++ b/src/ogx_client/lib/stream_printer.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from .agents.event_logger import TurnStreamEventPrinter
 from .inference.event_logger import InferenceStreamLogEventPrinter
 

--- a/src/ogx_client/lib/tools/mcp_oauth.py
+++ b/src/ogx_client/lib/tools/mcp_oauth.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import os

--- a/src/ogx_client/pagination.py
+++ b/src/ogx_client/pagination.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List, Generic, TypeVar, Optional

--- a/src/ogx_client/resources/__init__.py
+++ b/src/ogx_client/resources/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from .chat import (

--- a/src/ogx_client/resources/alpha/__init__.py
+++ b/src/ogx_client/resources/alpha/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from .admin import (

--- a/src/ogx_client/resources/alpha/admin.py
+++ b/src/ogx_client/resources/alpha/admin.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/alpha/alpha.py
+++ b/src/ogx_client/resources/alpha/alpha.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/alpha/inference.py
+++ b/src/ogx_client/resources/alpha/inference.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/batches.py
+++ b/src/ogx_client/resources/batches.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/chat/__init__.py
+++ b/src/ogx_client/resources/chat/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from .chat import (

--- a/src/ogx_client/resources/chat/chat.py
+++ b/src/ogx_client/resources/chat/chat.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/chat/completions.py
+++ b/src/ogx_client/resources/chat/completions.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/completions.py
+++ b/src/ogx_client/resources/completions.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/conversations/__init__.py
+++ b/src/ogx_client/resources/conversations/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from .items import (

--- a/src/ogx_client/resources/conversations/conversations.py
+++ b/src/ogx_client/resources/conversations/conversations.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/conversations/items.py
+++ b/src/ogx_client/resources/conversations/items.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/embeddings.py
+++ b/src/ogx_client/resources/embeddings.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/files.py
+++ b/src/ogx_client/resources/files.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/inspect.py
+++ b/src/ogx_client/resources/inspect.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/models/__init__.py
+++ b/src/ogx_client/resources/models/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from .models import (

--- a/src/ogx_client/resources/models/models.py
+++ b/src/ogx_client/resources/models/models.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/models/openai.py
+++ b/src/ogx_client/resources/models/openai.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/moderations.py
+++ b/src/ogx_client/resources/moderations.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/prompts/__init__.py
+++ b/src/ogx_client/resources/prompts/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from .prompts import (

--- a/src/ogx_client/resources/prompts/prompts.py
+++ b/src/ogx_client/resources/prompts/prompts.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/prompts/versions.py
+++ b/src/ogx_client/resources/prompts/versions.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/providers.py
+++ b/src/ogx_client/resources/providers.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/responses/__init__.py
+++ b/src/ogx_client/resources/responses/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from .responses import (

--- a/src/ogx_client/resources/responses/input_items.py
+++ b/src/ogx_client/resources/responses/input_items.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/responses/responses.py
+++ b/src/ogx_client/resources/responses/responses.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/routes.py
+++ b/src/ogx_client/resources/routes.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/safety.py
+++ b/src/ogx_client/resources/safety.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/shields.py
+++ b/src/ogx_client/resources/shields.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/vector_io.py
+++ b/src/ogx_client/resources/vector_io.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/vector_stores/__init__.py
+++ b/src/ogx_client/resources/vector_stores/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from .files import (

--- a/src/ogx_client/resources/vector_stores/file_batches.py
+++ b/src/ogx_client/resources/vector_stores/file_batches.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/vector_stores/files.py
+++ b/src/ogx_client/resources/vector_stores/files.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/resources/vector_stores/vector_stores.py
+++ b/src/ogx_client/resources/vector_stores/vector_stores.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/__init__.py
+++ b/src/ogx_client/types/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/alpha/__init__.py
+++ b/src/ogx_client/types/alpha/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/alpha/admin_list_routes_params.py
+++ b/src/ogx_client/types/alpha/admin_list_routes_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/alpha/inference_rerank_params.py
+++ b/src/ogx_client/types/alpha/inference_rerank_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/alpha/inference_rerank_response.py
+++ b/src/ogx_client/types/alpha/inference_rerank_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List

--- a/src/ogx_client/types/alpha/post_training/job_artifacts_params.py
+++ b/src/ogx_client/types/alpha/post_training/job_artifacts_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/alpha/post_training/job_cancel_params.py
+++ b/src/ogx_client/types/alpha/post_training/job_cancel_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/alpha/post_training/job_status_params.py
+++ b/src/ogx_client/types/alpha/post_training/job_status_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/batch_cancel_response.py
+++ b/src/ogx_client/types/batch_cancel_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import builtins

--- a/src/ogx_client/types/batch_create_params.py
+++ b/src/ogx_client/types/batch_create_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/batch_create_response.py
+++ b/src/ogx_client/types/batch_create_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import builtins

--- a/src/ogx_client/types/batch_list_params.py
+++ b/src/ogx_client/types/batch_list_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/batch_list_response.py
+++ b/src/ogx_client/types/batch_list_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import builtins

--- a/src/ogx_client/types/batch_retrieve_response.py
+++ b/src/ogx_client/types/batch_retrieve_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import builtins

--- a/src/ogx_client/types/chat/__init__.py
+++ b/src/ogx_client/types/chat/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/chat/completion_create_params.py
+++ b/src/ogx_client/types/chat/completion_create_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/chat/completion_create_response.py
+++ b/src/ogx_client/types/chat/completion_create_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, List, Union, Optional

--- a/src/ogx_client/types/chat/completion_list_params.py
+++ b/src/ogx_client/types/chat/completion_list_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/chat/completion_list_response.py
+++ b/src/ogx_client/types/chat/completion_list_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import TYPE_CHECKING, Dict, List, Union, Optional

--- a/src/ogx_client/types/chat/completion_retrieve_response.py
+++ b/src/ogx_client/types/chat/completion_retrieve_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import TYPE_CHECKING, Dict, List, Union, Optional

--- a/src/ogx_client/types/chat_completion_chunk.py
+++ b/src/ogx_client/types/chat_completion_chunk.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List, Optional

--- a/src/ogx_client/types/completion_create_params.py
+++ b/src/ogx_client/types/completion_create_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/completion_create_response.py
+++ b/src/ogx_client/types/completion_create_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List, Optional

--- a/src/ogx_client/types/conversation_create_params.py
+++ b/src/ogx_client/types/conversation_create_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/conversation_delete_response.py
+++ b/src/ogx_client/types/conversation_delete_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Optional

--- a/src/ogx_client/types/conversation_object.py
+++ b/src/ogx_client/types/conversation_object.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, List, Optional

--- a/src/ogx_client/types/conversation_update_params.py
+++ b/src/ogx_client/types/conversation_update_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/conversations/__init__.py
+++ b/src/ogx_client/types/conversations/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/conversations/item_create_params.py
+++ b/src/ogx_client/types/conversations/item_create_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/conversations/item_create_response.py
+++ b/src/ogx_client/types/conversations/item_create_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, List, Union, Optional

--- a/src/ogx_client/types/conversations/item_delete_response.py
+++ b/src/ogx_client/types/conversations/item_delete_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Optional

--- a/src/ogx_client/types/conversations/item_get_response.py
+++ b/src/ogx_client/types/conversations/item_get_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, List, Union, Optional

--- a/src/ogx_client/types/conversations/item_list_params.py
+++ b/src/ogx_client/types/conversations/item_list_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/conversations/item_list_response.py
+++ b/src/ogx_client/types/conversations/item_list_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, List, Union, Optional

--- a/src/ogx_client/types/create_embeddings_response.py
+++ b/src/ogx_client/types/create_embeddings_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List, Union, Optional

--- a/src/ogx_client/types/create_response.py
+++ b/src/ogx_client/types/create_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, List, Optional

--- a/src/ogx_client/types/delete_file_response.py
+++ b/src/ogx_client/types/delete_file_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Optional

--- a/src/ogx_client/types/embedding_create_params.py
+++ b/src/ogx_client/types/embedding_create_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/file.py
+++ b/src/ogx_client/types/file.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Optional

--- a/src/ogx_client/types/file_content_response.py
+++ b/src/ogx_client/types/file_content_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing_extensions import TypeAlias

--- a/src/ogx_client/types/file_create_params.py
+++ b/src/ogx_client/types/file_create_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/file_list_params.py
+++ b/src/ogx_client/types/file_list_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/list_files_response.py
+++ b/src/ogx_client/types/list_files_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List, Optional

--- a/src/ogx_client/types/list_models_response.py
+++ b/src/ogx_client/types/list_models_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List, Optional

--- a/src/ogx_client/types/list_prompts_response.py
+++ b/src/ogx_client/types/list_prompts_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from .._models import BaseModel

--- a/src/ogx_client/types/list_shields_response.py
+++ b/src/ogx_client/types/list_shields_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from .._models import BaseModel

--- a/src/ogx_client/types/list_vector_stores_response.py
+++ b/src/ogx_client/types/list_vector_stores_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List, Optional

--- a/src/ogx_client/types/model.py
+++ b/src/ogx_client/types/model.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, Optional

--- a/src/ogx_client/types/model_retrieve_response.py
+++ b/src/ogx_client/types/model_retrieve_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import builtins

--- a/src/ogx_client/types/models/__init__.py
+++ b/src/ogx_client/types/models/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/moderation_create_params.py
+++ b/src/ogx_client/types/moderation_create_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/prompt.py
+++ b/src/ogx_client/types/prompt.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List, Optional

--- a/src/ogx_client/types/prompt_create_params.py
+++ b/src/ogx_client/types/prompt_create_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/prompt_list_response.py
+++ b/src/ogx_client/types/prompt_list_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List

--- a/src/ogx_client/types/prompt_retrieve_params.py
+++ b/src/ogx_client/types/prompt_retrieve_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/prompt_set_default_version_params.py
+++ b/src/ogx_client/types/prompt_set_default_version_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/prompt_update_params.py
+++ b/src/ogx_client/types/prompt_update_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/prompts/__init__.py
+++ b/src/ogx_client/types/prompts/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/provider_list_response.py
+++ b/src/ogx_client/types/provider_list_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List

--- a/src/ogx_client/types/query_chunks_response.py
+++ b/src/ogx_client/types/query_chunks_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, List, Union, Optional

--- a/src/ogx_client/types/response_create_params.py
+++ b/src/ogx_client/types/response_create_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/response_delete_response.py
+++ b/src/ogx_client/types/response_delete_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Optional

--- a/src/ogx_client/types/response_list_params.py
+++ b/src/ogx_client/types/response_list_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/response_list_response.py
+++ b/src/ogx_client/types/response_list_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, List, Union, Optional

--- a/src/ogx_client/types/response_object.py
+++ b/src/ogx_client/types/response_object.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, List, Union, Optional

--- a/src/ogx_client/types/response_object_stream.py
+++ b/src/ogx_client/types/response_object_stream.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, List, Union, Optional

--- a/src/ogx_client/types/responses/__init__.py
+++ b/src/ogx_client/types/responses/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/responses/input_item_list_params.py
+++ b/src/ogx_client/types/responses/input_item_list_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/responses/input_item_list_response.py
+++ b/src/ogx_client/types/responses/input_item_list_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, List, Union, Optional

--- a/src/ogx_client/types/route_list_params.py
+++ b/src/ogx_client/types/route_list_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/route_list_response.py
+++ b/src/ogx_client/types/route_list_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List

--- a/src/ogx_client/types/run_shield_response.py
+++ b/src/ogx_client/types/run_shield_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Optional

--- a/src/ogx_client/types/safety_run_shield_params.py
+++ b/src/ogx_client/types/safety_run_shield_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/scoring_fn_params.py
+++ b/src/ogx_client/types/scoring_fn_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List, Union, Optional

--- a/src/ogx_client/types/scoring_fn_params_param.py
+++ b/src/ogx_client/types/scoring_fn_params_param.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/shared/__init__.py
+++ b/src/ogx_client/types/shared/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from .param_type import ParamType as ParamType

--- a/src/ogx_client/types/shared/health_info.py
+++ b/src/ogx_client/types/shared/health_info.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing_extensions import Literal

--- a/src/ogx_client/types/shared/interleaved_content.py
+++ b/src/ogx_client/types/shared/interleaved_content.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List, Union, Optional

--- a/src/ogx_client/types/shared/interleaved_content_item.py
+++ b/src/ogx_client/types/shared/interleaved_content_item.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Union, Optional

--- a/src/ogx_client/types/shared/list_providers_response.py
+++ b/src/ogx_client/types/shared/list_providers_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from ..._models import BaseModel

--- a/src/ogx_client/types/shared/list_routes_response.py
+++ b/src/ogx_client/types/shared/list_routes_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from ..._models import BaseModel

--- a/src/ogx_client/types/shared/param_type.py
+++ b/src/ogx_client/types/shared/param_type.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Union, Optional

--- a/src/ogx_client/types/shared/provider_info.py
+++ b/src/ogx_client/types/shared/provider_info.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict

--- a/src/ogx_client/types/shared/route_info.py
+++ b/src/ogx_client/types/shared/route_info.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List

--- a/src/ogx_client/types/shared/safety_violation.py
+++ b/src/ogx_client/types/shared/safety_violation.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, Optional

--- a/src/ogx_client/types/shared/sampling_params.py
+++ b/src/ogx_client/types/shared/sampling_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List, Union, Optional

--- a/src/ogx_client/types/shared/system_message.py
+++ b/src/ogx_client/types/shared/system_message.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List, Union, Optional

--- a/src/ogx_client/types/shared/version_info.py
+++ b/src/ogx_client/types/shared/version_info.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from ..._models import BaseModel

--- a/src/ogx_client/types/shield.py
+++ b/src/ogx_client/types/shield.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, Optional

--- a/src/ogx_client/types/shield_list_response.py
+++ b/src/ogx_client/types/shield_list_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List

--- a/src/ogx_client/types/shield_register_params.py
+++ b/src/ogx_client/types/shield_register_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/vector_io_insert_params.py
+++ b/src/ogx_client/types/vector_io_insert_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/vector_io_query_params.py
+++ b/src/ogx_client/types/vector_io_query_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/vector_store.py
+++ b/src/ogx_client/types/vector_store.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, Optional

--- a/src/ogx_client/types/vector_store_create_params.py
+++ b/src/ogx_client/types/vector_store_create_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/vector_store_delete_response.py
+++ b/src/ogx_client/types/vector_store_delete_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Optional

--- a/src/ogx_client/types/vector_store_list_params.py
+++ b/src/ogx_client/types/vector_store_list_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/vector_store_search_params.py
+++ b/src/ogx_client/types/vector_store_search_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/vector_store_search_response.py
+++ b/src/ogx_client/types/vector_store_search_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, List, Union, Optional

--- a/src/ogx_client/types/vector_store_update_params.py
+++ b/src/ogx_client/types/vector_store_update_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/vector_stores/__init__.py
+++ b/src/ogx_client/types/vector_stores/__init__.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/vector_stores/file_batch_create_params.py
+++ b/src/ogx_client/types/vector_stores/file_batch_create_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/vector_stores/file_batch_list_files_params.py
+++ b/src/ogx_client/types/vector_stores/file_batch_list_files_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/vector_stores/file_content_params.py
+++ b/src/ogx_client/types/vector_stores/file_content_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/vector_stores/file_content_response.py
+++ b/src/ogx_client/types/vector_stores/file_content_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, List, Optional

--- a/src/ogx_client/types/vector_stores/file_create_params.py
+++ b/src/ogx_client/types/vector_stores/file_create_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/vector_stores/file_delete_response.py
+++ b/src/ogx_client/types/vector_stores/file_delete_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Optional

--- a/src/ogx_client/types/vector_stores/file_list_params.py
+++ b/src/ogx_client/types/vector_stores/file_list_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/vector_stores/file_update_params.py
+++ b/src/ogx_client/types/vector_stores/file_update_params.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/src/ogx_client/types/vector_stores/list_vector_store_files_in_batch_response.py
+++ b/src/ogx_client/types/vector_stores/list_vector_store_files_in_batch_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List, Optional

--- a/src/ogx_client/types/vector_stores/vector_store_file.py
+++ b/src/ogx_client/types/vector_stores/vector_store_file.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict, Union, Optional

--- a/src/ogx_client/types/vector_stores/vector_store_file_batches.py
+++ b/src/ogx_client/types/vector_stores/vector_store_file_batches.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Optional

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,1 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.

--- a/tests/api_resources/__init__.py
+++ b/tests/api_resources/__init__.py
@@ -1,7 +1,1 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.

--- a/tests/api_resources/alpha/__init__.py
+++ b/tests/api_resources/alpha/__init__.py
@@ -1,7 +1,1 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.

--- a/tests/api_resources/alpha/test_admin.py
+++ b/tests/api_resources/alpha/test_admin.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/alpha/test_inference.py
+++ b/tests/api_resources/alpha/test_inference.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/chat/__init__.py
+++ b/tests/api_resources/chat/__init__.py
@@ -1,7 +1,1 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.

--- a/tests/api_resources/chat/test_completions.py
+++ b/tests/api_resources/chat/test_completions.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/conversations/__init__.py
+++ b/tests/api_resources/conversations/__init__.py
@@ -1,7 +1,1 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.

--- a/tests/api_resources/conversations/test_items.py
+++ b/tests/api_resources/conversations/test_items.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/models/__init__.py
+++ b/tests/api_resources/models/__init__.py
@@ -1,7 +1,1 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.

--- a/tests/api_resources/models/test_openai.py
+++ b/tests/api_resources/models/test_openai.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/prompts/__init__.py
+++ b/tests/api_resources/prompts/__init__.py
@@ -1,7 +1,1 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.

--- a/tests/api_resources/prompts/test_versions.py
+++ b/tests/api_resources/prompts/test_versions.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/responses/__init__.py
+++ b/tests/api_resources/responses/__init__.py
@@ -1,7 +1,1 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.

--- a/tests/api_resources/responses/test_input_items.py
+++ b/tests/api_resources/responses/test_input_items.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_batches.py
+++ b/tests/api_resources/test_batches.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_completions.py
+++ b/tests/api_resources/test_completions.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_conversations.py
+++ b/tests/api_resources/test_conversations.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_embeddings.py
+++ b/tests/api_resources/test_embeddings.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_files.py
+++ b/tests/api_resources/test_files.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_inspect.py
+++ b/tests/api_resources/test_inspect.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_models.py
+++ b/tests/api_resources/test_models.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_moderations.py
+++ b/tests/api_resources/test_moderations.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_prompts.py
+++ b/tests/api_resources/test_prompts.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_providers.py
+++ b/tests/api_resources/test_providers.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_responses.py
+++ b/tests/api_resources/test_responses.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_routes.py
+++ b/tests/api_resources/test_routes.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_safety.py
+++ b/tests/api_resources/test_safety.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_shields.py
+++ b/tests/api_resources/test_shields.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_vector_io.py
+++ b/tests/api_resources/test_vector_io.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/test_vector_stores.py
+++ b/tests/api_resources/test_vector_stores.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/vector_stores/__init__.py
+++ b/tests/api_resources/vector_stores/__init__.py
@@ -1,7 +1,1 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.

--- a/tests/api_resources/vector_stores/test_file_batches.py
+++ b/tests/api_resources/vector_stores/test_file_batches.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/api_resources/vector_stores/test_files.py
+++ b/tests/api_resources/vector_stores/test_files.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/integration/test_agent_responses_e2e.py
+++ b/tests/integration/test_agent_responses_e2e.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import io
 import os
 import time

--- a/tests/integration/test_agent_turn_step_events.py
+++ b/tests/integration/test_agent_turn_step_events.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 """Integration tests for agent turn/step event model.
 
 These tests verify the core architecture of the turn/step event system:

--- a/tests/lib/agents/test_agent_responses.py
+++ b/tests/lib/agents/test_agent_responses.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 from types import SimpleNamespace

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations

--- a/tests/test_extract_files.py
+++ b/tests/test_extract_files.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 from typing import Sequence

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from pathlib import Path
 
 import anyio

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import json
 from typing import TYPE_CHECKING, Any, Dict, List, Union, Optional, cast
 from datetime import datetime, timezone

--- a/tests/test_qs.py
+++ b/tests/test_qs.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from typing import Any, cast
 from functools import partial
 from urllib.parse import unquote

--- a/tests/test_required_args.py
+++ b/tests/test_required_args.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import pytest

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import json
 from typing import Any, List, Union, cast
 from typing_extensions import Annotated

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 from typing import Iterator, AsyncIterator

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import io

--- a/tests/test_utils/test_datetime_parse.py
+++ b/tests/test_utils/test_datetime_parse.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 """
 Copied from https://github.com/pydantic/pydantic/blob/v1.10.22/tests/test_datetime_parse.py
 with modifications so it works without pydantic v1 imports.

--- a/tests/test_utils/test_json.py
+++ b/tests/test_utils/test_json.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import datetime

--- a/tests/test_utils/test_path.py
+++ b/tests/test_utils/test_path.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 from typing import Any

--- a/tests/test_utils/test_proxy.py
+++ b/tests/test_utils/test_proxy.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 import operator
 from typing import Any
 from typing_extensions import override

--- a/tests/test_utils/test_typing.py
+++ b/tests/test_utils/test_typing.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 from typing import Generic, TypeVar, cast

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
## Summary
This is no longer a project requiring a meta license. Two-commit cleanup:

1. **Drop the pre-commit hook + header file** so new files don't get re-stamped:
   - Remove the \`insert-license\` hook from \`.pre-commit-config.yaml\`
   - Delete \`scripts/license_header.txt\` (the Meta-attribution header it injected)
2. **Strip existing headers** from every \`.py\` / \`.sh\` in the tree (286 files) — removes the 5-line \`Copyright (c) Meta Platforms, Inc. and affiliates\` block.

## Test plan
- [x] No \`Meta Platforms\` references remain anywhere in the tree
- [x] \`.pre-commit-config.yaml\` parses; remaining hooks (ruff, ruff-format, blacken-docs, etc.) are untouched
- [ ] CI: pre-commit job is green and no longer runs \`insert-license\`