### PR TITLE
feat: restore provider_data constructor kwarg

### DIFF
--- a/src/ogx_client/_client.py
+++ b/src/ogx_client/_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import json
 from typing import TYPE_CHECKING, Any, Mapping
 from typing_extensions import Self, override
 
@@ -112,6 +113,7 @@ class OgxClient(SyncAPIClient):
         # outlining your use-case to help us decide if it should be
         # part of our public interface in the future.
         _strict_response_validation: bool = False,
+        provider_data: Mapping[str, Any] | None = None,
     ) -> None:
         """Construct a new synchronous OgxClient client instance.
 
@@ -134,6 +136,12 @@ class OgxClient(SyncAPIClient):
                 if colon >= 0:
                     parsed[line[:colon].strip()] = line[colon + 1 :].strip()
             default_headers = {**parsed, **(default_headers if is_mapping_t(default_headers) else {})}
+
+        if provider_data is not None:
+            default_headers = {
+                **(default_headers if is_mapping_t(default_headers) else {}),
+                "X-OGX-Provider-Data": json.dumps(provider_data),
+            }
 
         super().__init__(
             version=__version__,
@@ -436,6 +444,7 @@ class AsyncOgxClient(AsyncAPIClient):
         # outlining your use-case to help us decide if it should be
         # part of our public interface in the future.
         _strict_response_validation: bool = False,
+        provider_data: Mapping[str, Any] | None = None,
     ) -> None:
         """Construct a new async AsyncOgxClient client instance.
 
@@ -458,6 +467,12 @@ class AsyncOgxClient(AsyncAPIClient):
                 if colon >= 0:
                     parsed[line[:colon].strip()] = line[colon + 1 :].strip()
             default_headers = {**parsed, **(default_headers if is_mapping_t(default_headers) else {})}
+
+        if provider_data is not None:
+            default_headers = {
+                **(default_headers if is_mapping_t(default_headers) else {}),
+                "X-OGX-Provider-Data": json.dumps(provider_data),
+            }
 
         super().__init__(
             version=__version__,


### PR DESCRIPTION
## Summary

Adds back the `provider_data: Mapping[str, Any] | None` kwarg on `OgxClient` and `AsyncOgxClient` that was present in the previous `llama-stack-client` SDK but lost during the rename to `ogx-client`. When provided, it is JSON-serialized and merged into `default_headers` under `X-OGX-Provider-Data` — the header the OGX server reads to thread per-request provider credentials through.

## Why

Without this kwarg, every caller upgrading from `llama-stack-client` has to construct the header themselves on every client instantiation:

```python
OgxClient(
    base_url=...,
    default_headers={"X-OGX-Provider-Data": json.dumps(get_provider_data())},
)
```

That breaks a large surface of OGX integration tests and downstream code on upgrade. Restoring the affordance keeps the migration to `ogx-client` source-compatible for the constructor signature.

## Behavior matches the old SDK

The previous implementation in `llama-stack-client` v0.7.2-alpha.3 was:

```python
custom_headers = default_headers or {}
if provider_data is not None:
    custom_headers["X-LlamaStack-Provider-Data"] = json.dumps(provider_data)
```

This PR mirrors that, with the only intentional difference being the header name (`X-OGX-Provider-Data`, matching the renamed server).

## Test plan

- [x] `OgxClient(base_url=..., provider_data={"k": "v"})` accepts the kwarg
- [x] `client.default_headers["X-OGX-Provider-Data"]` contains `{"k": "v"}` JSON-encoded
- [x] Same for `AsyncOgxClient`